### PR TITLE
Correct the bin path in composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Edit `.git/hooks/commit-msg` to look like this (and make it executable).
 ```
 #!/bin/sh
 
-bin/git-lint-validators git-lint-validator:hook $1
+vendor/bin/git-lint-validators git-lint-validator:hook $1
 ```
 
 It's fairly customisable too, here are some options:
 
 ```
-$ bin/git-lint-validators help git-lint-validator:hook
+$ vendor/bin/git-lint-validators help git-lint-validator:hook
 Usage:
   git-lint-validator:hook [options] [--] <commit-message-file>
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "php": "^7.0.0",
     "symfony/console": "^3.1"
   },
-  "bin": ["bin/git-github-lint"],
+  "bin": ["bin/git-lint-validators"],
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
This corrects the bin path in composer. This will allow the user to use
the library as described in README, rather than as if you were running
the binary from this file
