### PR TITLE
Enforce scruitinzer checks

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -99,3 +99,8 @@ build:
             -
                 command: 'vendor/bin/phpspec run -n'
 
+build_failure_conditions:
+    - 'elements.rating(<= D).exists'
+    - 'issues.new.exists'
+    - 'project.metric("scrutinizer.quality", < 9)'
+    - 'project.metric("scrutinizer.quality", < -0.5)'

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -95,4 +95,7 @@ build:
     tests:
         override:
             -
+                command: 'find src spec -name "*.php" -print0 | xargs -0 -n1 -P8 php -l'
+            -
                 command: 'vendor/bin/phpspec run -n'
+

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -22,8 +22,8 @@ checks:
         newline_at_end_of_file: true
         naming_conventions:
             local_variable: '^[a-z][a-zA-Z0-9]*$'
-            abstract_class_name: ^Abstract|Factory$
-            utility_class_name: 'Utils?$'
+            abstract_class_name: '^Abstract[A-Z][A-Za-z0-9]*$'
+            utility_class_name: '^[A-Z][A-Z0-9a-z]*$'
             constant_name: '^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$'
             property_name: '^[a-z][a-zA-Z0-9]*$'
             method_name: '^(?:[a-z]|__)[a-zA-Z0-9]*$'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_script:
   - composer install
 
 script:
+  - find src spec -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
   - vendor/bin/phpspec run

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ composer install
 We follow PSR2, and also enforce PHPDocs on all functions. To run the tests for coding style violations
 
 ```bash
-vendor/bin/phpcs -p --standard=psr2 src/ spec/
+vendor/bin/phpcs -p --standard=psr2 src/
 ```
 
 ### Unit tests


### PR DESCRIPTION
Currently scrutinizer doesn't break for new issues.
This will ensure that that happens so we don't
accidentally allow in new issues
