### PR TITLE
Indicate Git commit message format via template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2016-mm-dd
+### Added
+
+- A composer script to install and configure a git commit message template (Thanks @raphaelstolt)
+
 ## [1.1.0] - 2016-08-09
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Help:
 
 ```
 
+#### Git commit message template installation
+
+Use the `install-git-commit-message-template` Composer script to install and configure a [commit message template] following the [rules of Chris Beams].
+The commit message template is written to `.git/.gitmessage` and will than be used when issuing a `git commit` w/o the message option.
+
+```bash
+composer install-git-commit-message-template
+```
+
+[commit message template]: https://robots.thoughtbot.com/better-commit-messages-with-a-gitmessage-template
+[rules of Chris Beams]: http://chris.beams.io/posts/git-commit/#seven-rules
+
 #### Output While Running
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
   "scripts": {
     "install-git-hook": [
       "PurpleBooth\\GitLintValidators\\Composer\\Scripts::installGitMessageHook"
+    ],
+    "install-git-commit-message-template": [
+      "PurpleBooth\\GitLintValidators\\Composer\\Scripts::installGitCommitMessageTemplate"
     ]
   },
   "autoload": {

--- a/src/PurpleBooth/GitLintValidators/Composer/Scripts.php
+++ b/src/PurpleBooth/GitLintValidators/Composer/Scripts.php
@@ -2,14 +2,16 @@
 declare(strict_types = 1);
 namespace PurpleBooth\GitLintValidators\Composer;
 
+use Composer\IO\IOInterface;
 use Composer\Script\Event;
 
 class Scripts
 {
-    const BACKUP_EXTENSION = '.bak';
-    const GIT_PATH         = '.git';
-    const HOOKS_PATH       = 'hooks';
-    const HOOK_FILENAME    = 'commit-msg';
+    const BACKUP_EXTENSION  = '.bak';
+    const GIT_PATH          = '.git';
+    const HOOKS_PATH        = 'hooks';
+    const HOOK_FILENAME     = 'commit-msg';
+    const TEMPLATE_FILENAME = '.gitmessage';
 
     /**
      * Default Permissions (Copied from example hooks)
@@ -23,6 +25,20 @@ class Scripts
 #!/bin/sh
 
 vendor/bin/git-lint-validators git-lint-validator:hook $1
+CONTENT;
+
+    const TEMPLATE_CONTENTS = <<<CONTENT
+Subject line
+
+# - Capitalise the subject line and do not end it with a period
+# - Use the imperative mood in the subject line
+# - Summarise changes in around 50 (soft limit, hard limit at 69)
+#   characters or less in the subject line
+# - Separate subject line from body with a blank line
+Subject body
+# - Use the subject body to explain what and why vs. how
+# - Wrap the subject body at 72 characters
+
 CONTENT;
 
     /**
@@ -42,14 +58,12 @@ CONTENT;
         $question   .= "commit message hook? ";
 
         if ($inputOutput->askConfirmation($question, false)) {
-            $gitDirectory = implode(DIRECTORY_SEPARATOR, [dirname(__DIR__, 4), self::GIT_PATH]);
+            $errorMessage  = "Couldn't locate the .git directory. ";
+            $errorMessage .= "Aborting the Git hook installation.";
 
-            if (!is_dir($gitDirectory)) {
-                $errorMessage  = "Couldn't locate the .git directory. ";
-                $errorMessage .= "Aborting the Git hook installation.";
+            $gitDirectory = self::getGuardedGitDirectory($errorMessage, $inputOutput);
 
-                $inputOutput->error($errorMessage);
-
+            if ($gitDirectory === false) {
                 return false;
             }
 
@@ -84,5 +98,74 @@ CONTENT;
         $inputOutput->write("Aborted installation and activation of the Git commit message hook.");
 
         return false;
+    }
+
+    /**
+     * Installs and configures the Git commit message
+     * template when confirmed by the user.
+     *
+     * @param  Event $event The script event.
+     *
+     * @return boolean
+     */
+    public static function installGitCommitMessageTemplate(Event $event)
+    {
+        $templateContent = self::TEMPLATE_CONTENTS;
+        $inputOutput     = $event->getIO();
+        $question        = "Do you want to install and configure the Git ";
+        $question       .= "commit message template? ";
+
+        if ($inputOutput->askConfirmation($question, false)) {
+            $errorMessage  = "Couldn't locate the .git directory. ";
+            $errorMessage .= "Aborting the Git commit message template installation.";
+
+            $gitDirectory = self::getGuardedGitDirectory($errorMessage, $inputOutput);
+
+            if ($gitDirectory === false) {
+                return false;
+            }
+
+            $templateFile = implode(DIRECTORY_SEPARATOR, [$gitDirectory, self::TEMPLATE_FILENAME]);
+
+            file_put_contents($templateFile, $templateContent);
+            $gitConfigureCommand = "git config --add commit.template $templateFile";
+            exec($gitConfigureCommand);
+
+            $inputOutput->write("Installed and configured the Git commit message template.");
+
+            if ($inputOutput->isVerbose()) {
+                $inputOutput->write("Wrote");
+                $inputOutput->write("<comment>$templateContent</comment>");
+                $inputOutput->write("into <info>$templateFile</info> and configured the Git commit message template ");
+                $inputOutput->write("via <comment>$gitConfigureCommand</comment>.");
+            }
+
+            return true;
+        }
+
+        $inputOutput->write("Aborted installation and configuration of the Git commit message template.");
+
+        return false;
+    }
+
+    /**
+     * Returns the .git directory if present. Errors the given
+     * message if not.
+     *
+     * @param  string      $message     The message to error.
+     * @param  IOInterface $inputOutput The Input/Output helper interface.
+     *
+     * @return false|string
+     */
+    private static function getGuardedGitDirectory($message, IOInterface $inputOutput)
+    {
+        $gitDirectory = implode(DIRECTORY_SEPARATOR, [dirname(__DIR__, 4), self::GIT_PATH]);
+
+        if (!is_dir($gitDirectory)) {
+            $inputOutput->error($message);
+            return false;
+        }
+
+        return $gitDirectory;
     }
 }


### PR DESCRIPTION
Adds a Composer script which installs a Git commit message template into `.git/.gitmessage` and configures it as a [commit template](https://robots.thoughtbot.com/better-commit-messages-with-a-gitmessage-template) which is used when doing a `git commit`.
